### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update]
+  before_action :authorize_user!, only: [:edit, :update]
 
   def index
     @items = Item.order('created_at DESC')
@@ -10,11 +12,10 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def create
-    @item = Item.new(item_params)
+    @item = Item.new(create_item_params)
     if @item.save
       redirect_to root_path
     else
@@ -22,10 +23,44 @@ class ItemsController < ApplicationController
     end
   end
 
-  private
+  def destroy
+    item.destroy
+    redirect_to root_path
+  end
 
-  def item_params
+  def edit
+  end
+
+
+ def update
+  if current_user == @item.user
+    if @item.update(update_item_params) 
+      redirect_to @item
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  else
+    redirect_to root_path
+  end
+end
+
+private
+ def set_item
+    @item = Item.find(params[:id])
+  end
+
+ def create_item_params
     params.require(:item).permit(:image, :item_title, :item_description, :category_id, :item_condition_id,
-                                 :shipping_fee_payer_id, :prefecture_id, :shipping_day_id, :sales_price).merge(user_id: current_user.id)
+                                 :shipping_fee_payer_id, :prefecture_id, :shipping_day_id, :sales_price)
+                         .merge(user_id: current_user.id)
+ end
+ def update_item_params
+    params.require(:item).permit(:image, :item_title, :item_description, :category_id, :item_condition_id,
+                                 :shipping_fee_payer_id, :prefecture_id, :shipping_day_id, :sales_price)
+ end
+
+  def authorize_user!
+    #@item = Item.find(params[:id]) # 商品情報を取得
+    redirect_to root_path,  unless @item.user == current_user
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,7 +24,7 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    item.destroy
+    @item.destroy
     redirect_to root_path
   end
 
@@ -42,25 +42,28 @@ class ItemsController < ApplicationController
   else
     redirect_to root_path
   end
-end
+ end
 
-private
+ private
  def set_item
     @item = Item.find(params[:id])
-  end
+ end
 
  def create_item_params
     params.require(:item).permit(:image, :item_title, :item_description, :category_id, :item_condition_id,
                                  :shipping_fee_payer_id, :prefecture_id, :shipping_day_id, :sales_price)
                          .merge(user_id: current_user.id)
  end
+
  def update_item_params
     params.require(:item).permit(:image, :item_title, :item_description, :category_id, :item_condition_id,
                                  :shipping_fee_payer_id, :prefecture_id, :shipping_day_id, :sales_price)
  end
 
   def authorize_user!
-    #@item = Item.find(params[:id]) # 商品情報を取得
-    redirect_to root_path,  unless @item.user == current_user
+    unless @item.user == current_user
+     redirect_to root_path
+    end
   end
-end
+  
+end  

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,11 +7,8 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
-
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%= form_with model: @item, local: true do |f| %>
+    <%= render 'shared/error_messages', model: f.object %>
 
     <%# 商品画像 %>
     <div class="img-upload">
@@ -23,7 +20,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, class:"item-image" %>
       </div>
     </div>
     <%# /商品画像 %>
@@ -33,13 +30,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :item_title, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :item_description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +49,13 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, { class:"select-box", id:"item-category" }) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        
+        <%= f.collection_select(:item_condition_id, ItemCondition.all, :id, :name, {}, { class:"select-box", id:"item-sales-status" }) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +71,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_fee_payer_id, ShippingFeePayer.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shipping_day_id, ShippingDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +99,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :sales_price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -141,7 +139,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', item_path(@item), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,11 +25,9 @@
     </div>
 <% if user_signed_in? %>
  <% if @item.user == current_user %> <%# && @item.sold_out == false%>
-    <%= link_to "商品の編集", "#" , method: :get, class: "item-red-btn" %>
-    <%#= link_to "商品の編集", edit_item_path(@item.id) , method: :get, class: "item-red-btn" %>
+    <%= link_to "商品の編集", edit_item_path(@item.id) , method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#" , data: {turbo_method: :delete}, class:"item-destroy" %>
-    <%#= link_to "削除", item_path(@item.id), data: {turbo_method: :delete}, class:"item-destroy" %>
+    <%= link_to "削除", item_path(@item.id), data: {turbo_method: :delete}, class:"item-destroy" %>
  <% else %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
  <% end %>


### PR DESCRIPTION
# What
商品情報編集機能の実装

# Why
商品情報編集機能のため


ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/69fa9a49993236122177a170a3f125c9

必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
https://gyazo.com/8f0aac82ec0c81cd424da22237e49a79

入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
https://gyazo.com/8a3b49f8f48ca680a8b7ab27118c1cbf

何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
https://gyazo.com/cf883531ebce9f55853b7d45b47c837c

ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/1fbec7c6eec2d3e09b5929c0fe7600c1

ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/b470c9483088c20f2cc89617f625c17b

商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
https://gyazo.com/4fbc09ecbf7948302c7ebe3810c5bfcf